### PR TITLE
fix: Import necessary testing modules to fix the tests.

### DIFF
--- a/Example_Code/AngularQuizApp/src/app/app.component.spec.ts
+++ b/Example_Code/AngularQuizApp/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { NgModule, NO_ERRORS_SCHEMA, Component } from '@angular/core';
-import { TestBed, async } from '@angular/core/testing';
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import { RouterOutlet } from '@angular/router';
 import { AppComponent } from './app.component';
 import { DataService } from './data.service';
@@ -8,8 +8,13 @@ import { StatisticsComponent } from './statistics/statistics.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
 import { TopicsComponent } from './topics/topics.component';
 import { WelcomePageComponent } from './welcome-page/welcome-page.component';
+import { By } from '@angular/platform-browser';
 
 describe('AppComponent', () => {
+
+  let component: AppComponent;
+  let fixture: ComponentFixture<AppComponent>;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -17,30 +22,24 @@ describe('AppComponent', () => {
         ToolbarComponent
       ],
       schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
+    }).compileComponents()
+      .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          fixture.detectChanges();
+      });
   }));
 
   it('should create the app', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
   }));
-  it(`should have as title 'app'`, async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
-  }));
-  it('should render title in a h1 tag', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Would they lie to you? Fake news education');
-  }));
-});
 
-@Component({
-  selector: 'app-toolbar', 
-  template: ''
-})
-class MockToolbarComponent {
-}
+  // TODO: This test needs an h1 element in app component to work. If there isn't going to be an h1
+  //  element, this test can be deleted.
+  //
+  // it('should render title in a h1 tag', async(() => {
+  //   const compiled = fixture.debugElement.query(By.css('h1'));
+  //   expect(compiled.nativeElement.textContent).toContain('Would they lie to you? Fake news education');
+  // }));
+});

--- a/Example_Code/AngularQuizApp/src/app/app.component.ts
+++ b/Example_Code/AngularQuizApp/src/app/app.component.ts
@@ -14,7 +14,7 @@ import { QuizComponent } from './quiz/quiz.component';
       <app-social></app-social>
     </div>`
 })
-export class AppComponent implements OnInit{
+export class AppComponent implements OnInit {
   constructor () {}
   ngOnInit () {}
 }

--- a/Example_Code/AngularQuizApp/src/app/data.service.spec.ts
+++ b/Example_Code/AngularQuizApp/src/app/data.service.spec.ts
@@ -1,9 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { DataService } from './data.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('DataService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ HttpClientTestingModule ]
+    }).compileComponents();
+  });
 
   it('should be created', () => {
     const service: DataService = TestBed.get(DataService);

--- a/Example_Code/AngularQuizApp/src/app/quiz/quiz.component.spec.ts
+++ b/Example_Code/AngularQuizApp/src/app/quiz/quiz.component.spec.ts
@@ -2,8 +2,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { QuizComponent } from './quiz.component';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('QuizComponent', () => {
   let component: QuizComponent;
@@ -11,6 +14,17 @@ describe('QuizComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+
+      // TODO: Instead of importing these, you could mock the services that are used in the
+      //  constructor of QuizComponent, i.e.:
+      //  constructor(
+      //     private quizService: QuizService,
+      //     private dataService: DataService,
+      //     private route: ActivatedRoute
+      //  ) { }
+      //  to actually test the behaviour (i.e. checking if the respective functions of the services
+      //  are bing called etc.).
+      imports: [ FormsModule, HttpClientTestingModule, RouterTestingModule ],
       declarations: [ QuizComponent ]
     })
     .compileComponents();

--- a/Example_Code/AngularQuizApp/src/app/statistics/statistics.component.spec.ts
+++ b/Example_Code/AngularQuizApp/src/app/statistics/statistics.component.spec.ts
@@ -2,6 +2,8 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { StatisticsComponent } from './statistics.component';
+import { RouterTestingModule } from '@angular/router/testing';
+
 
 describe('StatisticsComponent', () => {
   let component: StatisticsComponent;
@@ -9,16 +11,15 @@ describe('StatisticsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ StatisticsComponent ]
-    })
-    .compileComponents();
+      declarations: [ StatisticsComponent ],
+      imports: [ RouterTestingModule ]
+    }).compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(StatisticsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
   }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(StatisticsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/Example_Code/AngularQuizApp/src/app/statistics/statistics.component.ts
+++ b/Example_Code/AngularQuizApp/src/app/statistics/statistics.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+
 
 @Component({
   selector: 'app-statistics',

--- a/Example_Code/AngularQuizApp/src/app/topics/topics.component.spec.ts
+++ b/Example_Code/AngularQuizApp/src/app/topics/topics.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TopicsComponent } from './topics.component';
 
@@ -8,7 +9,8 @@ describe('TopicsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TopicsComponent ]
+      imports: [ RouterTestingModule ],
+      declarations: [ TopicsComponent ],
     })
     .compileComponents();
   }));

--- a/Example_Code/AngularQuizApp/src/app/welcome-page/welcome-page.component.spec.ts
+++ b/Example_Code/AngularQuizApp/src/app/welcome-page/welcome-page.component.spec.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterOutlet } from '@angular/router';
-import {  NO_ERRORS_SCHEMA } from '@angular/core'
+import {  NO_ERRORS_SCHEMA } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
 import { WelcomePageComponent } from './welcome-page.component';
 
 describe('WelcomePageComponent', () => {
@@ -10,27 +10,18 @@ describe('WelcomePageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ WelcomePageComponent,
-      RouterOutlet ],
+      imports: [ RouterTestingModule ],
+      declarations: [ WelcomePageComponent ],
       schemas: [NO_ERRORS_SCHEMA]
-    })
-    .compileComponents();
+    }).compileComponents()
+      .then(() => {
+      fixture = TestBed.createComponent(WelcomePageComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
   }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(WelcomePageComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 });
-
-@Component({
-  selector: 'router-outlet', 
-  template: ''
-})
-class MockRouterOutlet {
-}


### PR DESCRIPTION
Some of the tests you had defined were pointless (i.e. Example_Code/AngularQuizApp/src/app/app.component.spec.ts - `it(should have as title 'app')`; pointless because 1. App does not specify title variable, 2. It's not useful to just check for a value like that anyway.). These could be removed.

In other cases, the underlying modules used in the compoonents (i.e. `RouterOutlet`) were not mocked correctly in the tests. This can be fixed by importing the appropriate testing modules (i.e. `RouterTestingModule`).

Finally, the `beforeEach` scripts could be consolidated as shown.